### PR TITLE
✨ Feat: #44 lv5 구현

### DIFF
--- a/04HarryPotterSeries/04HarryPotterSeries/Data/UserDefaultsManager.swift
+++ b/04HarryPotterSeries/04HarryPotterSeries/Data/UserDefaultsManager.swift
@@ -1,0 +1,25 @@
+//
+//  UserDefaultsManager.swift
+//  04HarryPotterSeries
+//
+//  Created by Milou on 6/20/25.
+//
+
+import Foundation
+
+
+final class UserDefaultsManager {
+    static let shared = UserDefaultsManager()
+    
+    private let userDefaults = UserDefaults.standard
+    
+    func saveSummaryState(_ isExpanded: Bool, of bookTitle: String) {
+        let key = "summary_state_\(bookTitle)"
+        userDefaults.set(isExpanded, forKey: key)
+    }
+    
+    func loadSummaryState(of bookTitle: String) -> Bool {
+        let key = "summary_state_\(bookTitle)"
+        return userDefaults.bool(forKey: key)
+    }
+}

--- a/04HarryPotterSeries/04HarryPotterSeries/Scene/BookViewModel.swift
+++ b/04HarryPotterSeries/04HarryPotterSeries/Scene/BookViewModel.swift
@@ -77,7 +77,16 @@ final class BookViewModel {
         }
     }
     
+    func loadSummaryExpandedState() -> Bool {
+        return UserDefaultsManager.shared.loadSummaryState(of: bookTitle)
+    }
+    
+    func saveSummaryExpandedState(_ isExpanded: Bool) {
+        UserDefaultsManager.shared.saveSummaryState(isExpanded, of: bookTitle)
+    }
+    
     init(bookRepository: BookRepository) {
         self.bookRepository = bookRepository
     }
+    
 }

--- a/04HarryPotterSeries/04HarryPotterSeries/Scene/ViewControllers/BookViewController.swift
+++ b/04HarryPotterSeries/04HarryPotterSeries/Scene/ViewControllers/BookViewController.swift
@@ -84,6 +84,10 @@ class BookViewController: UIViewController {
         viewModel.onError = { [weak self] error in
             self?.showErrorAlert(error: error)
         }
+        
+        bookDetailView.summaryView.onExpandedStateChanged = { [weak self] isExpanded in
+            self?.viewModel.saveSummaryExpandedState(isExpanded)
+        }
     }
     
     private func updateUI() {
@@ -97,6 +101,7 @@ class BookViewController: UIViewController {
         bookDetailView.bookImageView.image = UIImage(named: viewModel.bookImageName)
         bookDetailView.dedicationView.content  = viewModel.dedication
         bookDetailView.summaryView.content  = viewModel.summary
+        bookDetailView.summaryView.initialExpandedState = viewModel.loadSummaryExpandedState()
         bookDetailView.chaptersView.chapters = viewModel.chapters
     }
     

--- a/04HarryPotterSeries/04HarryPotterSeries/Scene/Views/BookDetailView.swift
+++ b/04HarryPotterSeries/04HarryPotterSeries/Scene/Views/BookDetailView.swift
@@ -64,12 +64,7 @@ class BookDetailView: UIView {
         titleFont: .boldSystemFont(ofSize: 18),
     )
     
-    let summaryView = InfoStackView(
-        axis: .vertical,
-        title: "Summary",
-        titleFont: .boldSystemFont(ofSize: 18),
-    )
-    
+    let summaryView = SummaryView()
     let chaptersView = ChaptersView()
     
     private let contentHStackView = UIStackView().then {

--- a/04HarryPotterSeries/04HarryPotterSeries/Scene/Views/SummaryView.swift
+++ b/04HarryPotterSeries/04HarryPotterSeries/Scene/Views/SummaryView.swift
@@ -10,6 +10,28 @@ import SnapKit
 import Then
 
 final class SummaryView: UIView {
+    private let charaterLimit: Int = 450
+    
+    private var fullText = "" {
+        didSet {
+            updateUI()
+        }
+    }
+    
+    private var isExpanded: Bool = false {
+        didSet {
+            updateContent()
+        }
+    }
+    private var isButtonNeeded: Bool {
+        fullText.count >= charaterLimit
+    }
+    
+    var content: String? {
+        get { fullText }
+        set { fullText = newValue ?? "" }
+    }
+    
     private let titleLabel = UILabel().then {
         $0.text = "Summary"
         $0.font = .boldSystemFont(ofSize: 18)
@@ -34,11 +56,6 @@ final class SummaryView: UIView {
         $0.spacing = 8
     }
     
-    var content: String? {
-        get { contentLabel.text }
-        set { contentLabel.text = newValue }
-    }
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
@@ -53,11 +70,38 @@ final class SummaryView: UIView {
         
         [titleLabel, contentLabel, toggleButton]
             .forEach { summaryVStackView.addArrangedSubview($0) }
-        
         addSubview(summaryVStackView)
         
         summaryVStackView.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+        
+        toggleButton.addTarget(self, action: #selector(toggleButtonTapped), for: .touchUpInside)
+    }
+    
+    @objc
+    private func toggleButtonTapped() {
+        isExpanded.toggle()
+    }
+    
+    private func updateUI() {
+        toggleButton.isHidden = !isButtonNeeded
+        updateContent()
+    }
+    
+    private func updateContent() {
+        guard isButtonNeeded else {
+            contentLabel.text = fullText
+            return
+        }
+        
+        if isExpanded {
+            contentLabel.text = fullText
+            toggleButton.setTitle("접기", for: .normal)
+        } else {
+            let truncatedText = fullText.prefix(charaterLimit) + "..."
+            contentLabel.text = String(truncatedText)
+            toggleButton.setTitle("더보기", for: .normal)
         }
     }
 }

--- a/04HarryPotterSeries/04HarryPotterSeries/Scene/Views/SummaryView.swift
+++ b/04HarryPotterSeries/04HarryPotterSeries/Scene/Views/SummaryView.swift
@@ -12,24 +12,20 @@ import Then
 final class SummaryView: UIView {
     private let charaterLimit: Int = 450
     
-    private var fullText = "" {
+    var content = "" {
         didSet {
-            updateUI()
+            updateUI() // 글자 수에 따라 UI 변경
         }
     }
     
     private var isExpanded: Bool = false {
         didSet {
-            updateContent()
+            updateTextState()
         }
     }
-    private var isButtonNeeded: Bool {
-        fullText.count >= charaterLimit
-    }
     
-    var content: String? {
-        get { fullText }
-        set { fullText = newValue ?? "" }
+    private var isButtonNeeded: Bool {
+        content.count >= charaterLimit
     }
     
     private let titleLabel = UILabel().then {
@@ -86,20 +82,20 @@ final class SummaryView: UIView {
     
     private func updateUI() {
         toggleButton.isHidden = !isButtonNeeded
-        updateContent()
+        updateTextState()
     }
     
-    private func updateContent() {
+    private func updateTextState() {
         guard isButtonNeeded else {
-            contentLabel.text = fullText
+            contentLabel.text = content // 450자 미만일땐 풀텍스트
             return
         }
         
         if isExpanded {
-            contentLabel.text = fullText
+            contentLabel.text = content
             toggleButton.setTitle("접기", for: .normal)
         } else {
-            let truncatedText = fullText.prefix(charaterLimit) + "..."
+            let truncatedText = content.prefix(charaterLimit) + "..."
             contentLabel.text = String(truncatedText)
             toggleButton.setTitle("더보기", for: .normal)
         }

--- a/04HarryPotterSeries/04HarryPotterSeries/Scene/Views/SummaryView.swift
+++ b/04HarryPotterSeries/04HarryPotterSeries/Scene/Views/SummaryView.swift
@@ -18,6 +18,16 @@ final class SummaryView: UIView {
         }
     }
     
+    var initialExpandedState: Bool = false {
+        didSet {
+            if isButtonNeeded {
+                isExpanded = initialExpandedState
+            }
+        }
+    }
+    
+    var onExpandedStateChanged: ((Bool) -> Void)?
+    
     private var isExpanded: Bool = false {
         didSet {
             updateTextState()
@@ -74,12 +84,7 @@ final class SummaryView: UIView {
         
         toggleButton.addTarget(self, action: #selector(toggleButtonTapped), for: .touchUpInside)
     }
-    
-    @objc
-    private func toggleButtonTapped() {
-        isExpanded.toggle()
-    }
-    
+
     private func updateUI() {
         toggleButton.isHidden = !isButtonNeeded
         updateTextState()
@@ -99,5 +104,11 @@ final class SummaryView: UIView {
             contentLabel.text = String(truncatedText)
             toggleButton.setTitle("더보기", for: .normal)
         }
+    }
+    
+    @objc
+    private func toggleButtonTapped() {
+        isExpanded.toggle()
+        onExpandedStateChanged?(isExpanded)
     }
 }

--- a/04HarryPotterSeries/04HarryPotterSeries/Scene/Views/SummaryView.swift
+++ b/04HarryPotterSeries/04HarryPotterSeries/Scene/Views/SummaryView.swift
@@ -1,0 +1,63 @@
+//
+//  SummaryView.swift
+//  04HarryPotterSeries
+//
+//  Created by Milou on 6/19/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class SummaryView: UIView {
+    private let titleLabel = UILabel().then {
+        $0.text = "Summary"
+        $0.font = .boldSystemFont(ofSize: 18)
+        $0.textColor = .black
+    }
+    
+    private let contentLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 14)
+        $0.textColor = .gray
+        $0.numberOfLines = 0
+    }
+    
+    private let toggleButton = UIButton().then {
+        $0.setTitle("Show more", for: .normal)
+        $0.setTitleColor(.systemBlue, for: .normal)
+        $0.titleLabel?.font = .systemFont(ofSize: 14)
+        $0.contentHorizontalAlignment = .trailing
+    }
+    
+    private let summaryVStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 8
+    }
+    
+    var content: String? {
+        get { contentLabel.text }
+        set { contentLabel.text = newValue }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        backgroundColor = .clear
+        
+        [titleLabel, contentLabel, toggleButton]
+            .forEach { summaryVStackView.addArrangedSubview($0) }
+        
+        addSubview(summaryVStackView)
+        
+        summaryVStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #44

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->
📋 구현 내용
- Summary 텍스트가 450자 이상일 때 "더보기" 버튼 표시
- 450자 미만일 때는 전체 텍스트 표시 (더보기 버튼 숨김)
- 더보기/접기 상태를 UserDefaults에 저장하여 앱 재시작 후에도 상태 유지

🔧 주요 변경사항
- SummaryView: 텍스트 길이에 따른 동적 UI 처리 및 토글 기능 구현
- UserDefaultsManager: 사용자 설정 저장/로드를 위한 매니저 클래스 추가
- BookViewModel: Summary 상태 관리 메서드 추가
- BookViewController: SummaryView와 ViewModel 간 바인딩 처리

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->
  <img width="300" alt="" src="https://github.com/user-attachments/assets/0e39088e-5fa9-4dc9-a50f-5061777611b0">  
  <img width="300" alt="" src="https://github.com/user-attachments/assets/f33e39bd-5e56-4a8e-bc94-602caf08ed07">  

<br>
